### PR TITLE
Update getting-started.rst with Python 3 example

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -147,7 +147,7 @@ The result should look like:
 
 Note the ``value`` in the result (``61626364``); this is the
 hex-encoding of the ASCII of ``abcd``. You can verify this in
-a python shell by running ``"61626364".decode('hex')``. Stay
+a python 2 shell by running ``"61626364".decode('hex')`` or in python 3 shell by running ``import codecs; codecs.decode("61626364", 'hex').decode('ascii')``. Stay
 tuned for a future release that `makes this output more human-readable <https://github.com/tendermint/abci/issues/32>`__.
 
 Now let's try setting a different key and value:


### PR DESCRIPTION
When running the command `AttributeError: 'str' object has no attribute 'decode'` in Python 3 shell it returns error `AttributeError: 'str' object has no attribute 'decode'`. Since some users may be using Python 3 I have added an example code snippet for them that allows them to check that the Transaction stored the bytes "abcd" in the Merkle tree.

Python 3 Shell example showing the error and use of code snippet that returns desired result:
```
$ python3
Python 3.6.4rc1 (default, Dec 30 2017, 19:32:40) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> "61626364".decode('hex')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
>>> import codecs; codecs.decode("61626364", 'hex').decode('ascii')
'abcd'
```